### PR TITLE
[BACKEND-903] 'Marathon gets stuck with resident tasks' fix

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -2,10 +2,10 @@ package mesosphere.marathon.core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.{ TaskCondition, Task }
+import mesosphere.marathon.core.instance.Instance.Id
+import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
-
 import scala.collection.immutable.Seq
 
 sealed trait InstanceUpdateOperation {
@@ -67,5 +67,6 @@ object InstanceUpdateOperation {
   case class ReservationTimeout(instanceId: Instance.Id) extends InstanceUpdateOperation
 
   /** Expunge a task whose TaskOp was rejected */
-  case class ForceExpunge(instanceId: Instance.Id) extends InstanceUpdateOperation
+  case class ForceExpunge(instanceId: Id, unreserveAndDestroy: Boolean = false)
+    extends InstanceUpdateOperation
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
@@ -29,12 +29,12 @@ object InstanceOpFactory {
     * @param additionalLaunches the number of additional launches that has been requested
     */
   case class Request(runSpec: RunSpec, offer: Mesos.Offer, instanceMap: Map[Instance.Id, Instance],
-      additionalLaunches: Int) {
+      additionalLaunches: Int, reserveInFlight: Set[Instance.Id] = Set()) {
     def frameworkId: FrameworkId = FrameworkId("").mergeFromProto(offer.getFrameworkId)
     def instances: Seq[Instance] = instanceMap.values.to[Seq]
     lazy val reserved: Seq[Instance] = instances.filter(_.isReserved)
-    def hasWaitingReservations: Boolean = reserved.nonEmpty
-    def numberOfWaitingReservations: Int = reserved.size
+    def hasWaitingReservations: Boolean = reserved.nonEmpty || reserveInFlight.nonEmpty
+    def numberOfWaitingReservations: Int = reserved.size + reserveInFlight.size
     def isForResidentRunSpec: Boolean = runSpec.residency.isDefined
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -117,9 +117,11 @@ class InstanceOpFactoryImpl(
 
     val needToLaunch = additionalLaunches > 0 && request.hasWaitingReservations
     val needToReserve = request.numberOfWaitingReservations < additionalLaunches
-    val instances0 = request.instanceMap.mapValues(i => i.instanceId + " " + i.state.condition).mkString(", ")
-
-    log.debug(s"Need to launch $needToLaunch, need to reserve $needToReserve, additionalLaunches $additionalLaunches, instances [$instances0]")
+    if (log.isDebugEnabled) {
+      val instancesSummary = request.instanceMap.mapValues(i => i.instanceId + " " + i.state.condition).mkString(", ")
+      log.debug(s"Need to launch $needToLaunch, need to reserve $needToReserve, " +
+          s"additionalLaunches $additionalLaunches, instances [$instancesSummary]")
+    }
 
     /* *
      * If an offer HAS reservations/volumes that match our run spec, handling these has precedence
@@ -138,7 +140,7 @@ class InstanceOpFactoryImpl(
 
     def maybeLaunchOnReservation: Option[OfferMatchResult] = if (needToLaunch) {
       val maybeVolumeMatch = PersistentVolumeMatcher.matchVolumes(offer, request.reserved)
-      log.debug(s"Matched volumes: ${maybeVolumeMatch.nonEmpty}")
+      log.debug("Has matched volumes: %s", maybeVolumeMatch.nonEmpty)
 
       maybeVolumeMatch.map { volumeMatch =>
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
@@ -74,7 +74,7 @@ private[reconcile] class OfferMatcherReconciler(instanceTracker: InstanceTracker
             case (taskId, spuriousResources) if spurious(taskId.instanceId) =>
               val unreserveAndDestroy =
                 InstanceOp.UnreserveAndDestroyVolumes(
-                  stateOp = InstanceUpdateOperation.ForceExpunge(taskId.instanceId),
+                  stateOp = InstanceUpdateOperation.ForceExpunge(taskId.instanceId, true),
                   oldInstance = instancesBySpec.instance(taskId.instanceId),
                   resources = spuriousResources
                 )

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -64,6 +64,9 @@ private[jobs] object OverdueTasksActor {
       val unconfirmedExpire = now - config.taskLaunchConfirmTimeout().millis
 
       def launchedAndExpired(task: Task): Boolean = {
+        val unconfirmed = task.status.stagedAt < unconfirmedExpire
+        val stageExpired = task.status.stagedAt < stagedExpire
+        log.debug(s"${task.taskId} condition ${task.status.condition}, unconfirmed $unconfirmed, stageExpired $stageExpired")
         task.status.condition match {
           case Condition.Created | Condition.Starting if task.status.stagedAt < unconfirmedExpire =>
             log.warn(s"Should kill: ${task.taskId} was launched " +

--- a/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
@@ -4,19 +4,26 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task.Reservation
 import mesosphere.marathon.stream._
 import org.apache.mesos.{ Protos => Mesos }
-
+import org.slf4j.LoggerFactory
 import scala.collection.immutable.Seq
 
 object PersistentVolumeMatcher {
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
   def matchVolumes(
     offer: Mesos.Offer,
     waitingInstances: Seq[Instance]): Option[VolumeMatch] = {
 
     // find all offered persistent volumes
+    val withDisk = offer.getResourcesList.count(r => r.hasDisk)
+    val withPersistence = offer.getResourcesList.count(r => r.hasDisk && r.getDisk.hasPersistence)
     val availableVolumes: Map[String, Mesos.Resource] = offer.getResourcesList.collect {
       case resource: Mesos.Resource if resource.hasDisk && resource.getDisk.hasPersistence =>
         resource.getDisk.getPersistence.getId -> resource
     }(collection.breakOut)
+
+    val pids = availableVolumes.keys.mkString(", ")
+    log.debug(s"withDisk $withDisk, withPersist $withPersistence, pids [$pids]")
 
     def resourcesForReservation(reservation: Reservation): Option[Seq[Mesos.Resource]] = {
       if (reservation.volumeIds.map(_.idString).forall(availableVolumes.contains))

--- a/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
@@ -3,7 +3,9 @@ package mesosphere.mesos
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task.Reservation
 import mesosphere.marathon.stream._
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.Protos.Offer
+import org.apache.mesos.Protos.Resource
+import org.apache.mesos.{Protos => Mesos}
 import org.slf4j.LoggerFactory
 import scala.collection.immutable.Seq
 
@@ -15,17 +17,15 @@ object PersistentVolumeMatcher {
     waitingInstances: Seq[Instance]): Option[VolumeMatch] = {
 
     // find all offered persistent volumes
-    val withDisk = offer.getResourcesList.count(r => r.hasDisk)
-    val withPersistence = offer.getResourcesList.count(r => r.hasDisk && r.getDisk.hasPersistence)
-    val availableVolumes: Map[String, Mesos.Resource] = offer.getResourcesList.collect {
-      case resource: Mesos.Resource if resource.hasDisk && resource.getDisk.hasPersistence =>
+
+    val availableVolumes: Map[String, Resource] = offer.getResourcesList.collect {
+      case resource: Resource if resource.hasDisk && resource.getDisk.hasPersistence =>
         resource.getDisk.getPersistence.getId -> resource
     }(collection.breakOut)
 
-    val pids = availableVolumes.keys.mkString(", ")
-    log.debug(s"withDisk $withDisk, withPersist $withPersistence, pids [$pids]")
+    logOfferPersistentVolumeStatus(offer, availableVolumes)
 
-    def resourcesForReservation(reservation: Reservation): Option[Seq[Mesos.Resource]] = {
+    def resourcesForReservation(reservation: Reservation): Option[Seq[Resource]] = {
       if (reservation.volumeIds.map(_.idString).forall(availableVolumes.contains))
         Some(reservation.volumeIds.flatMap(id => availableVolumes.get(id.idString)))
       else
@@ -39,6 +39,18 @@ object PersistentVolumeMatcher {
           resourcesForReservation(reservation).flatMap(rs => Some(VolumeMatch(instance, rs)))
         }
       }.headOption
+  }
+
+  private def logOfferPersistentVolumeStatus(
+    offer: Offer,
+    availableVolumes: Map[String, Resource]
+  ) = {
+    if (log.isDebugEnabled) {
+      val withDisk = offer.getResourcesList.count(r => r.hasDisk)
+      val withPersistence = offer.getResourcesList.count(r => r.hasDisk && r.getDisk.hasPersistence)
+      val pids = availableVolumes.keys.mkString(", ")
+      log.debug(s"withDisk $withDisk, withPersist $withPersistence, pids [$pids]")
+    }
   }
 
   case class VolumeMatch(instance: Instance, persistentVolumeResources: Seq[Mesos.Resource])

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -50,7 +50,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     val expectedOps =
       Seq(
         InstanceOp.UnreserveAndDestroyVolumes(
-          InstanceUpdateOperation.ForceExpunge(taskId.instanceId),
+          InstanceUpdateOperation.ForceExpunge(taskId.instanceId, true),
           oldInstance = None,
           resources = offer.getResourcesList.to[Seq]
         )
@@ -79,7 +79,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     Then("all resources are destroyed and unreserved")
     val expectedOps = Seq(
       InstanceOp.UnreserveAndDestroyVolumes(
-        InstanceUpdateOperation.ForceExpunge(taskId.instanceId),
+        InstanceUpdateOperation.ForceExpunge(taskId.instanceId, true),
         oldInstance = None,
         resources = offer.getResourcesList.to[Seq]
       )
@@ -108,7 +108,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     Then("all resources are destroyed and unreserved")
     val expectedOps = Seq(
       InstanceOp.UnreserveAndDestroyVolumes(
-        InstanceUpdateOperation.ForceExpunge(taskId.instanceId),
+        InstanceUpdateOperation.ForceExpunge(taskId.instanceId, true),
         oldInstance = Some(bogusInstance),
         resources = offer.getResourcesList.to[Seq]
       )


### PR DESCRIPTION
**Changes summary**

- if we receive an offer with volumes, we don't throw ISE if no instances exist for them
- before we send a reserve request, we check how many requests we have sent already

**Context description**
From an *app* description Marathon creates multiple *Tasks*(*Instances* of the app). 
For scaling up/restarting/changing parameters of the app each time Marathon creates _TaskLauncherActor_ which will process offers (match them to the tasks resource requirements) and produce high-level events _LaunchEphemeral/LaunchOnReservation/Reserve_ (which eventually trigger requests to Mesos).
Task lifecycle well-represented here https://goo.gl/p3u9wa (please see before reading further)
When an offer is received and we have an app with PV (persistent volume) requirement then the important steps are:
1. Check there is sufficient disk space.
2. Check PV exists.
 2.1. If exists, check labels match to any of the existing tasks.
  2.1.1. If match, then create LaunchOnReservation for the matched task.
3. If PV doesn't exist, check all tasks have reservations.
  3.1. If any task needs reservation, then create Reserve.

If we create Reserve, then Mesos should eventually create a volume (labeled for a particular task) and send us back an offer with that volume. After that we could launch the task using that offer (LaunchOnReservation). There can be more volumes than tasks. (Those volumes will wait "eternally" for the tasks linked to them until we destroy the app or shutdown the agent.)
 
 

